### PR TITLE
Fix GameScene syntax errors

### DIFF
--- a/Color Critters!/GameScene.swift
+++ b/Color Critters!/GameScene.swift
@@ -1706,16 +1706,18 @@ class GameScene: SKScene, AdManagerDelegate, AnimalGalleryDelegate, MiniGameDele
                     SKAction.scale(to: 1.0, duration: 0.3)
                 ])
                 blob.run(hint)
-                
+
                 // Add a glow effect
                 let glow = SKSpriteNode(color: .systemYellow, size: CGSize(width: 80, height: 80))
                 glow.alpha = 0.5
                 glow.position = blob.position
                 glow.zPosition = blob.zPosition - 1
-    func galleryDidClose() {
-        animalGallery?.removeFromParent()
-        animalGallery = nil
-    }
+                addChild(glow)
+                let fadeOut = SKAction.fadeOut(withDuration: 0.6)
+                let remove = SKAction.removeFromParent()
+                glow.run(SKAction.sequence([fadeOut, remove]))
+            }
+        }
     }
     
     // MARK: - MiniGameDelegate


### PR DESCRIPTION
## Summary
- close `showColorHint` function properly
- remove stray nested `galleryDidClose` function
- add fade-out animation for hint glow

## Testing
- `swiftc "Color Critters!/GameScene.swift" -parse`
- `find 'Color Critters!' -name '*.swift' -print0 | xargs -0 -n1 swiftc -parse`
- `xcodebuild -project "Color Critters!.xcodeproj" -scheme "Color Critters!" -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 15' build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6888e5eba7c0832a9739dac9a9e55eb6